### PR TITLE
Bug 1 Fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,5 +21,5 @@ module.exports = function highlight (query, text, opts) {
   var match = '<' + opts.tag + '>' + text.slice(offset, offset + last + 1) + '</' + opts.tag + '>'
   var after = highlight(query.slice(last + 1), text.slice(offset + last + 1), opts)
 
-  return before + match + after
+  return after === null ? null : before + match + after
 }

--- a/test.js
+++ b/test.js
@@ -40,3 +40,8 @@ test('specify tag', (t) => {
 
   t.end()
 })
+
+test('query is too long', (t) => {
+  t.is(highlight('brown', 'brow'), null)
+  t.end()
+})


### PR DESCRIPTION
Fixes https://github.com/uiureo/fuzzysearch-highlight/issues/1

Now when the query is longer than the text, it returns `null` as expected.